### PR TITLE
Extend AMI resource to accept owners filter and support output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --no-cache add py2-pip jq
+RUN apk --no-cache add py3-pip jq
 
 RUN pip --no-cache-dir --disable-pip-version-check install awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --no-cache add py3-pip jq
+RUN apk --no-cache add bash py3-pip jq
 
 RUN pip --no-cache-dir --disable-pip-version-check install awscli
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Concourse CI resource to check for new Amazon Machine Images (AMI).
 
 - `region`: *Required.* The AWS region to search for AMIs.
 
+- `owners`: A list of owners to filter for. See the `--owners` flag in the AWS CLI [describe-images](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html) documentation.
+
 - `filters`: *Required.* A map of named filters to their values. Check the AWS CLI [describe-images](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html) documentation for a complete list of acceptable filters and values.
 
 If `aws_access_key_id` and `aws_secret_access_key` are both absent, AWS CLI will fall back to other authentication mechanisms. See [Configuration setting and precedence](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ Places the following files in the destination:
   {"source_ami": "ami-5731123e"}
   ```
 
+### `out`: Check that an AMI exists
+
+For bookkeeping in Concourse—generates a new version immediately so it can be passed to the next job in a pipeline without needing a `check` to run. Expects a JSON file at `input/json` with an object containing an `ImageId` property e.g.
+
+```json
+{
+  "ImageId": "ami-...",
+  ...
+}
+```
+
+`input` can be overridden with the put params `input` e.g.
+
+```json
+put: my-image
+params:
+  input: other-input
+```
+
+in which case the JSON file is expected at `other-input/json`.
+
 #### Parameters
 
 *None.*

--- a/bin/check
+++ b/bin/check
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -eu -o pipefail
 exec 3>&1 1>&2
 
@@ -21,7 +21,14 @@ fi
 
 jq '.source.filters | to_entries | map({"Name": .key, "Values": [(.value|select(type!="array") = [.])|.[]|tostring]})' /tmp/input > /tmp/filters.json
 
+owners_args=()
+mapfile -t owners <(jq '.source.owners | .[]? | tostring' /tmp/input)
+if [[ ${#owners[@]} -gt 0 ]]; then
+  owner_args=(--owners "${owner[@]}")
+fi
+
 aws ec2 describe-images \
   --filters file:///tmp/filters.json \
+  "${owner_args[@]}" \
   --query 'sort_by(Images, &CreationDate)' \
   | jq '.[([.[] | .ImageId] | index("'$AMI'") // -2) + 1:] | [.[] | {ami: .ImageId}]' >&3

--- a/bin/out
+++ b/bin/out
@@ -1,5 +1,60 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# Does not create an AMI, but generates a Concourse resource version to reflect an already-created AMI. Helpful when a version must be used on-demand rather than waiting for a `check`.
 set -eu -o pipefail
 exec 3>&1 1>&2
 
-cat | jq '{version}' <&0 >&3
+src=$1
+
+# input:
+# {
+#   "source": {
+#     "aws_access_key_id": "...",
+#     "aws_secret_access_key": "...",
+#     "filters": "...",
+#     "owners": ...,
+#     "region": "eu-central-1"
+#   },
+#   "params": {
+#     "input": "..."
+#   }
+# }
+
+jq . > /tmp/input
+
+export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' /tmp/input)
+export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' /tmp/input)
+export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' /tmp/input)
+
+input=$(jq -r '.params.input // "image"' /tmp/input)
+image_id=$(jq -r .ImageId "${src}/${input}/json")
+
+echo 'Filters:'
+jq --arg image_id "${image_id}" \
+    '.source.filters
+    | to_entries
+    | map({"Name": .key, "Values": [(.value|select(type!="array") = [.])|.[]|tostring]})
+    | . + [{Name: "image-id", Values: [$image_id]}]
+    ' \
+    /tmp/input \
+  | tee /tmp/filters.json
+
+owners_args=()
+mapfile -t owners <(jq '.source.owners | .[]? | tostring' /tmp/input)
+if [[ ${#owners[@]} -gt 0 ]]; then
+  echo "Owners" "${owner[@]}"
+  owner_args=(--owners "${owner[@]}")
+fi
+
+found_image=$(
+  aws ec2 describe-images \
+      --filters file:///tmp/filters.json \
+      "${owner_args[@]}" \
+      --query 'sort_by(Images, &CreationDate)' \
+    | jq 'length > 0'
+)
+if [[ ${found_image} == false ]]; then
+  echo 'Image ${image_id} not found'
+  exit 1
+fi
+
+jq --arg image_id "${image_id}" -n '{version:{ami:$image_id}}' >&3


### PR DESCRIPTION
Update to python3

Support filtering by owners which is separate from the Name,Values filters.

Implement out/put for the AMI resource that checks that an AMI exists.
